### PR TITLE
Add missing extern qualifiers in ircterm.h

### DIFF
--- a/include/ircterm.h
+++ b/include/ircterm.h
@@ -89,9 +89,9 @@ extern	char	*CM,
 extern	int	SG;
 /**************************** PATCHED by Flier ******************************/
 #ifdef WANTANSI
-char            *SETAF,
+extern char     *SETAF,
                 *SETAB;
-int             NUMCOLORS;
+extern int      NUMCOLORS;
 #endif /* WANTANSI */
 /****************************************************************************/
 


### PR DESCRIPTION
This fixes compiling with -fno-common, which is now the default on new versions of gcc and clang.
(See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=85678)