### PR TITLE
(Hopefully) fix possible memory leak

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ config.cache
 config.log
 config.status
 include/defs.h
+include/defs.h.old
 ircbug
 scrollz.1
 source/*.o

--- a/source/blowfish.c
+++ b/source/blowfish.c
@@ -129,8 +129,8 @@ static unsigned int SBOX[NUMSBOX][256] = {
 };
 
 #ifdef HAVE_GMP
-extern FishDecrypt _((char *, char *, char *, int));
-extern FishEncrypt _((char *, char *, char *, int, int));
+extern int FishDecrypt _((char *, char *, char *, int));
+extern int FishEncrypt _((char *, char *, char *, int, int));
 #endif
 
 static unsigned int F(x)

--- a/source/dcc.c
+++ b/source/dcc.c
@@ -2897,6 +2897,7 @@ dcc_time(the_time)
 			btime->tm_year + 1900))
 		return buf;
 	else
+		new_free(&buf);
 		return empty_string;
 }
 

--- a/source/edit5.c
+++ b/source/edit5.c
@@ -3412,7 +3412,7 @@ int iscrypted;
     struct urlstr *urlnew, *tmpurl, *prevurl = NULL;
 
     if (line == NULL)
-        return;
+        return 0;
     strmcpy(tmpbuf1, line, sizeof(tmpbuf1));
     *tmpstr2 = '\0';
     while (*tmpstr1) {

--- a/source/fish.c
+++ b/source/fish.c
@@ -237,7 +237,10 @@ int encrypt_string(char *key, char *str, char *dest, int len) {
     s = (char *) malloc(len + 9);
     strncpy(s, str, len);
     s[len]=0;
-    if ((!key) || (!key[0])) return 0;
+    if ((!key) || (!key[0])) {
+		new_free(&s);
+		return 0;
+	}
     p = s;
     while (*p) p++;
     for (i = 0; i < 8; i++) *p++ = 0;


### PR DESCRIPTION
- dcc.c, fish.c: Fix memory leaks from ccc-analyzer
- edit5.c: ensure GrabURL always returns a value
- blowfish.c: declare FishEncrypt & FishDecrypt int
