### PR TITLE
parse.c: fix buffer overflow detected by _FORTIFY_SOURCE in snprintf

### DIFF
--- a/source/parse.c
+++ b/source/parse.c
@@ -1286,7 +1286,7 @@ p_channel(from, ArgList)
                             if (chan && chan->gotwho) *tmpbuf = '\0';
                             else snprintf(tmpbuf,sizeof(tmpbuf), "WHO %s", channel);
                             if (*channel != '+') {
-                                snprintf(&tmpbuf[strlen(tmpbuf)], sizeof(tmpbuf),
+                                snprintf(&tmpbuf[strlen(tmpbuf)], sizeof(tmpbuf) - strlen(tmpbuf),
                                         "\r\nMODE %s\r\nMODE %s e\r\nMODE %s b",
                                         channel, channel, channel);
                             }
@@ -1897,7 +1897,7 @@ p_part(from, ArgList)
 
                             snprintf(tmpbuf2, sizeof(tmpbuf2), "%s has left channel %s", from, channel);
                             if (comment && *comment)
-                                snprintf(&tmpbuf2[strlen(tmpbuf2)], sizeof(tmpbuf2), "(%s)", comment);
+                                snprintf(&tmpbuf2[strlen(tmpbuf2)], sizeof(tmpbuf2) - strlen(tmpbuf2), "(%s)", comment);
                             ChannelLogSave(tmpbuf2, chan);
                         }
                     }


### PR DESCRIPTION
## Summary

Two `snprintf()` calls in `parse.c` pass `sizeof(buf)` as the size argument while writing to an offset within the buffer (`&buf[strlen(buf)]`). glibc's `_FORTIFY_SOURCE=3` (default on Arch and other distros shipping gcc 14+) detects this at runtime via `__builtin_dynamic_object_size` and aborts the process with:

```
*** buffer overflow detected ***: terminated
```

The call in `p_channel()` (line 1289) is hit on every channel join when `chan->gotwho` is false (i.e. the first join), so on affected systems ScrollZ crashes the moment you join a channel. The call in `p_part()` (line 1900) has the same shape and is fixed for consistency.

## Fix

Pass the remaining space (`sizeof(buf) - strlen(buf)`) instead of the full buffer size.

## How to reproduce (before fix)

Build with default Arch CFLAGS (which include `-D_FORTIFY_SOURCE=3`), run `scrollz`, `/server <some-server>`, `/join #anything`. Process dies with SIGABRT immediately. Backtrace from coredumpctl:

```
#4  __fortify_fail
#5  __chk_fail
#6  __snprintf_chk
#7  p_channel (parse.c)
#8  irc2_parse_server (parse.c:1985)
```

## Test plan

- [x] Built scrollz with the patch on Arch (gcc 15, `_FORTIFY_SOURCE=3`)
- [x] Joined channel on EFnet — no abort, normal join behavior, MODE/WHO/MODE e/MODE b commands still sent to server
- [ ] Parts with messages still log correctly