### PR TITLE
edit6.c: use xterm-256 palette for mIRC colours, fix bg bounds

### DIFF
--- a/source/edit6.c
+++ b/source/edit6.c
@@ -1469,22 +1469,22 @@ char *newbuf;
     struct {
         char *fg, *bg;
     } codes[16] = {
-        { "[1;37m",   "[47m"        },      /* white                */
-        { "[0m",      "[40m"        },      /* black (grey for us)  */
-        { "[0;34m",   "[44m"        },      /* blue                 */
-        { "[0;32m",   "[42m"        },      /* green                */
-        { "[0;31m",   "[41m"        },      /* red                  */
-        { "[1;31m",   "[43m"        },      /* brown                */
-        { "[0;35m",   "[45m"        },      /* magenta              */
-        { "[0;33m",   "[46m"        },      /* bright red           */
-        { "[1;33m",   "[47m"        },      /* yellow               */
-        { "[1;32m",   "[42m"        },      /* bright green         */
-        { "[0;36m",   "[46m"        },      /* cyan                 */
-        { "[1;36m",   "[46m"        },      /* bright cyan          */
-        { "[1;34m",   "[44m"        },      /* bright blue          */
-        { "[1;35m",   "[45m"        },      /* bright magenta       */
-        { "[1;30m",   "[40m"        },      /* dark grey            */
-        { "[0;37m",   "[47m"        }       /* grey                 */
+        { "[38;5;15m",  "[48;5;15m"  },     /*  0 white             */
+        { "[38;5;16m",  "[48;5;16m"  },     /*  1 black             */
+        { "[38;5;19m",  "[48;5;19m"  },     /*  2 navy blue         */
+        { "[38;5;34m",  "[48;5;34m"  },     /*  3 green             */
+        { "[38;5;196m",  "[48;5;196m"  },     /*  4 red               */
+        { "[38;5;88m",  "[48;5;88m"  },     /*  5 maroon            */
+        { "[38;5;90m",  "[48;5;90m"  },     /*  6 purple            */
+        { "[38;5;208m",  "[48;5;208m"  },     /*  7 orange            */
+        { "[38;5;226m",  "[48;5;226m"  },     /*  8 yellow            */
+        { "[38;5;46m",  "[48;5;46m"  },     /*  9 light green       */
+        { "[38;5;30m",  "[48;5;30m"  },     /* 10 teal              */
+        { "[38;5;51m",  "[48;5;51m"  },     /* 11 cyan              */
+        { "[38;5;21m",  "[48;5;21m"  },     /* 12 royal blue        */
+        { "[38;5;201m",  "[48;5;201m"  },     /* 13 pink              */
+        { "[38;5;244m",  "[48;5;244m"  },     /* 14 grey              */
+        { "[38;5;252m",  "[48;5;252m"  }      /* 15 light grey        */
     };
     register char *sptr=buffer;
     register char *dptr=newbuf;
@@ -1505,7 +1505,7 @@ char *newbuf;
                 sptr++;
 	        code=(*sptr++)-'0';
 	        if (isdigit(*sptr)) code=code*10+(*sptr++)-'0';
-                if (code>0 && code<15 && DisplaymIRC==1) {
+                if (code>=0 && code<=15 && DisplaymIRC==1) {
                     strcpy(dptr,codes[code].bg);
                     while (*dptr) dptr++;
                 }


### PR DESCRIPTION
## Summary

`ConvertmIRC` in `edit6.c` mapped the 16 standard mIRC colours onto the 8-colour ANSI palette, with several entries that don't resemble the original colour.

The most visible case: **mIRC 7 (orange)** has its background set to `\033[46m` (cyan), so e.g. white-on-orange branding (Reddit) renders as white-on-**teal**.

This PR switches the table to `xterm-256` escapes (`\033[38;5;Nm` / `\033[48;5;Nm`) so each mIRC colour maps to a reasonable sRGB approximation:

| mIRC | name        | 256 | mIRC | name        | 256 |
|------|-------------|-----|------|-------------|-----|
| 0    | white       | 15  | 8    | yellow      | 226 |
| 1    | black       | 16  | 9    | light green | 46  |
| 2    | navy blue   | 19  | 10   | teal        | 30  |
| 3    | green       | 34  | 11   | cyan        | 51  |
| 4    | red         | 196 | 12   | royal blue  | 21  |
| 5    | maroon      | 88  | 13   | pink        | 201 |
| 6    | purple      | 90  | 14   | grey        | 244 |
| 7    | orange      | 208 | 15   | light grey  | 252 |

Also fixes a bounds bug on the background-colour parser: the old condition `code>0 && code<15` silently discarded `bg=0` (white) and `bg=15` (light grey). Changed to `code>=0 && code<=15`.

## Compatibility

Any terminal supporting 256 colours (xterm-256color, kitty, alacritty, modern xterm, screen/tmux with appropriate TERM) renders the new palette correctly. 8-colour-only terminals are very rare in 2026; for those a follow-up could read `tigetnum("colors")` and pick a fallback table, but that's out of scope here.

ChangeLog already mentions [256-colour support](https://github.com/ScrollZ/ScrollZ/blob/master/ChangeLog#L52-L54) for `ScrollZ.save` (FGx/BGx syntax), so 256-colour terminals are clearly an expected target.

## Test plan

- [x] Built and ran on Arch in kitty (TERM=xterm-kitty) — Reddit `\x0300,07 reddit \x03` now renders as white on orange, not white on teal.
- [x] mIRC 5 (maroon) BG and mIRC 7 (orange) BG visually correct.
- [ ] Verified no regression in CmdsColors / ScrollZ.save palette (those go through a different code path and are unaffected by this change).